### PR TITLE
Never emit a null k8s.pod.name resource attribute

### DIFF
--- a/.github/workflows/testrunner.yml
+++ b/.github/workflows/testrunner.yml
@@ -1,0 +1,26 @@
+name: "Test Runner"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  push:
+    branches:
+      - "main"
+
+# The action only checks out the repository and uploads the test results as an artifact, which the
+# Actions runtime token covers, so read access to the contents is all the job token needs.
+permissions:
+  contents: read
+
+jobs:
+  test-runner:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run tests
+        uses: likvido/action-test@v1.5
+        with:
+          test-target: src/Likvido.Web.sln
+          framework: net10.0
+          logger: GitHubActions

--- a/src/Likvido.Web.Tests/DependencyInjectionTests.cs
+++ b/src/Likvido.Web.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Xunit;
+
+namespace Likvido.Web.Tests;
+
+// Both tests mutate process-wide environment variables. Keeping them in a single class puts them in
+// one xunit collection, so they run sequentially and cannot race each other.
+public class DependencyInjectionTests
+{
+    // AddLikvidoWeb only wires up OpenTelemetry when it thinks it is running in a container, so the
+    // tests have to pretend they are - otherwise the interesting code path is skipped entirely.
+    private const string RunningInContainerVariable = "DOTNET_RUNNING_IN_CONTAINER";
+    private const string HostnameVariable = "HOSTNAME";
+
+    [Fact]
+    public void AddLikvidoWeb_WithoutHostname_ResolvesLoggerFactory()
+    {
+        // BuildKit does not set HOSTNAME inside a RUN step, so any test booting the application from
+        // a Docker build stage used to fail here with
+        // "Attribute value type is not an accepted primitive (Parameter 'k8s.pod.name')".
+        RunWithEnvironment(hostname: null, () =>
+        {
+            var provider = new ServiceCollection().AddLikvidoWeb("test-app").BuildServiceProvider();
+
+            var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("test");
+
+            logger.ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public void AddLikvidoWeb_WithHostname_ResolvesLoggerFactory()
+    {
+        RunWithEnvironment(hostname: "test-app-6c9f8d7b5c-2xq4t", () =>
+        {
+            var provider = new ServiceCollection().AddLikvidoWeb("test-app").BuildServiceProvider();
+
+            var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("test");
+
+            logger.ShouldNotBeNull();
+        });
+    }
+
+    // The service provider is deliberately not disposed: shutting down the OTLP exporter waits on a
+    // flush timeout against an endpoint that does not exist outside the cluster, which adds seconds
+    // of dead wall clock to every test.
+    private static void RunWithEnvironment(string? hostname, Action action)
+    {
+        var originalRunningInContainer = Environment.GetEnvironmentVariable(RunningInContainerVariable);
+        var originalHostname = Environment.GetEnvironmentVariable(HostnameVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(RunningInContainerVariable, "true");
+            Environment.SetEnvironmentVariable(HostnameVariable, hostname);
+
+            action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(RunningInContainerVariable, originalRunningInContainer);
+            Environment.SetEnvironmentVariable(HostnameVariable, originalHostname);
+        }
+    }
+}

--- a/src/Likvido.Web.Tests/Likvido.Web.Tests.csproj
+++ b/src/Likvido.Web.Tests/Likvido.Web.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+      <PackageReference Include="Shouldly" Version="4.3.0" />
+
+      <PackageReference Include="xunit" Version="2.9.3" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Likvido.Web\Likvido.Web.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Likvido.Web.sln
+++ b/src/Likvido.Web.sln
@@ -13,18 +13,48 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workflows", "Workflows", "{80A324BB-F698-4B68-A84E-B9BAF38EE3D8}"
 	ProjectSection(SolutionItems) = preProject
 		..\.github\workflows\nuget.yml = ..\.github\workflows\nuget.yml
+		..\.github\workflows\testrunner.yml = ..\.github\workflows\testrunner.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Likvido.Web.Tests", "Likvido.Web.Tests\Likvido.Web.Tests.csproj", "{D0A42D4B-4213-4411-8691-E4E1D09494D5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|x64.Build.0 = Debug|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Debug|x86.Build.0 = Debug|Any CPU
 		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|x64.ActiveCfg = Release|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|x64.Build.0 = Release|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC68067A-C4DE-4CD0-B2C5-1CF245449C15}.Release|x86.Build.0 = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|x64.Build.0 = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0A42D4B-4213-4411-8691-E4E1D09494D5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{80A324BB-F698-4B68-A84E-B9BAF38EE3D8} = {C3985174-97A0-455D-948F-DBC2A94681FA}

--- a/src/Likvido.Web/DependencyInjection.cs
+++ b/src/Likvido.Web/DependencyInjection.cs
@@ -32,7 +32,21 @@ public static class DependencyInjection
                     options.UseGrafana(settings =>
                     {
                         settings.ServiceName = webAppName;
-                        settings.ResourceAttributes.Add("k8s.pod.name", Environment.GetEnvironmentVariable("HOSTNAME"));
+
+                        var podName = Environment.GetEnvironmentVariable("HOSTNAME");
+                        if (string.IsNullOrWhiteSpace(podName))
+                        {
+                            // Not running in Kubernetes - e.g. a Docker build stage, where BuildKit does not
+                            // set HOSTNAME. MachineName is always populated, and in a pod it is the pod name
+                            // anyway. OpenTelemetry throws on a null attribute value, so this must not be null.
+                            podName = Environment.MachineName;
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(podName))
+                        {
+                            settings.ResourceAttributes.Add("k8s.pod.name", podName);
+                        }
+
                         settings.ExporterSettings = new AgentOtlpExporter
                         {
                             Protocol = OtlpExportProtocol.Grpc,

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.2.26</Version>
+        <Version>2.2.27</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
`AddLikvidoWeb` populated the `k8s.pod.name` resource attribute straight from `HOSTNAME`. Where
`HOSTNAME` is unset the value is `null`, and OpenTelemetry rejects a null attribute value rather than
skipping the attribute — `GrafanaOpenTelemetryResourceDetector.Detect()` hands the dictionary to
`new Resource(...)`, whose `SanitizeValue` type-tests the value against its accepted primitives,
matches nothing, and throws. `ResourceBuilder.Build()` has no catch, so host startup dies with:

```
System.ArgumentException: Attribute value type is not an accepted primitive (Parameter 'k8s.pod.name')
```

`HOSTNAME` is set in an interactive shell and by `docker run`, but **not** inside a BuildKit `RUN`
step — which is exactly where pull-request test gates run. So any consumer that both calls
`AddLikvidoWeb` and boots a `WebApplicationFactory` test from a Docker build stage had a broken gate,
while `dotnet test` locally and under `docker run` both passed. `Likvido.Mcp` works around it today
with `ENV HOSTNAME=dockerfile-test-stage`; that line goes away in a follow-up once this publishes.

`MachineName` is the fallback because inside a pod it *is* the pod name — `HOSTNAME`, the hostname and
the pod name are the same value there — so in-cluster telemetry is unchanged. The second guard is
belt and braces.

## Also here

The repository had no tests and no build workflow (`nuget.yml` only publishes, and only when
`version.props` changes), so nothing here would have caught this — it was found by a downstream
repository's Docker build. This adds a test project (laid out like `Likvido.Azure`'s) and a
`Test Runner` workflow on pull requests.

## Verification

Verified by mutation, not just by a green run: with the guard reverted, the `HOSTNAME`-unset test
fails with the exact `ArgumentException` above and the `HOSTNAME`-set test still passes. Reconfirmed
against the current `main` dependencies (net10.0, Grafana.OpenTelemetry 1.11.0), so this is not a
stale-version-only bug.

`version.props` is bumped to 2.2.27 in the same PR, since publishing is gated on that file changing.

Fixes Likvido/Likvido.App#27873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry reliability when the host name is unset or blank by using a safe fallback and avoiding invalid attribute values.

* **Tests**
  * Added new automated test coverage for dependency injection logging setup in both hostname-present and hostname-absent scenarios.
  * Added an automated GitHub Actions workflow to run tests on pushes to main and pull requests targeting main.

* **Chores**
  * Expanded solution build configurations to include x86 and x64, and added the new test project to the solution.
  * Updated the application version to 2.2.27.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->