### PR TITLE
Likvido/Likvido.App#27896 Export logs via Likvido.Telemetry

### DIFF
--- a/src/Likvido.Web.Tests/DependencyInjectionTests.cs
+++ b/src/Likvido.Web.Tests/DependencyInjectionTests.cs
@@ -5,8 +5,9 @@ using Xunit;
 
 namespace Likvido.Web.Tests;
 
-// These tests mutate process-wide environment variables. Keeping them in a single class puts them in
-// one xunit collection, so they run sequentially and cannot race each other.
+// These tests mutate process-wide environment variables, hence the shared collection — see
+// EnvironmentCollection.
+[Collection(EnvironmentCollection.Name)]
 public class DependencyInjectionTests
 {
     // Set by kubelet in every pod, and what Likvido.Telemetry reads to decide whether to export. The

--- a/src/Likvido.Web.Tests/DependencyInjectionTests.cs
+++ b/src/Likvido.Web.Tests/DependencyInjectionTests.cs
@@ -5,22 +5,23 @@ using Xunit;
 
 namespace Likvido.Web.Tests;
 
-// Both tests mutate process-wide environment variables. Keeping them in a single class puts them in
+// These tests mutate process-wide environment variables. Keeping them in a single class puts them in
 // one xunit collection, so they run sequentially and cannot race each other.
 public class DependencyInjectionTests
 {
-    // AddLikvidoWeb only wires up OpenTelemetry when it thinks it is running in a container, so the
-    // tests have to pretend they are - otherwise the interesting code path is skipped entirely.
-    private const string RunningInContainerVariable = "DOTNET_RUNNING_IN_CONTAINER";
-    private const string HostnameVariable = "HOSTNAME";
+    // Set by kubelet in every pod, and what Likvido.Telemetry reads to decide whether to export. The
+    // tests set it to exercise both sides of that decision through AddLikvidoWeb.
+    private const string KubernetesServiceHostVariable = "KUBERNETES_SERVICE_HOST";
+
+    // ⚠️ Cleared for the duration of every test. These tests run on a GitHub-hosted runner, where
+    // GITHUB_ACTIONS is "true" and Likvido.Telemetry therefore declines to export — which would make
+    // the in-a-pod test below quietly assert nothing in CI while still passing locally.
+    private const string GitHubActionsVariable = "GITHUB_ACTIONS";
 
     [Fact]
-    public void AddLikvidoWeb_WithoutHostname_ResolvesLoggerFactory()
+    public void AddLikvidoWeb_OutsideACluster_ResolvesLoggerFactory()
     {
-        // BuildKit does not set HOSTNAME inside a RUN step, so any test booting the application from
-        // a Docker build stage used to fail here with
-        // "Attribute value type is not an accepted primitive (Parameter 'k8s.pod.name')".
-        RunWithEnvironment(hostname: null, () =>
+        RunWithEnvironment(kubernetesServiceHost: null, () =>
         {
             var provider = new ServiceCollection().AddLikvidoWeb("test-app").BuildServiceProvider();
 
@@ -31,9 +32,12 @@ public class DependencyInjectionTests
     }
 
     [Fact]
-    public void AddLikvidoWeb_WithHostname_ResolvesLoggerFactory()
+    public void AddLikvidoWeb_InAPod_ResolvesLoggerFactory()
     {
-        RunWithEnvironment(hostname: "test-app-6c9f8d7b5c-2xq4t", () =>
+        // The path that wires up the OTLP exporter. What the exporter itself does with a missing
+        // HOSTNAME, and when it declines to export at all, belongs to Likvido.Telemetry and is
+        // covered by its own tests — this only proves AddLikvidoWeb composes with it.
+        RunWithEnvironment(kubernetesServiceHost: "172.19.0.1", () =>
         {
             var provider = new ServiceCollection().AddLikvidoWeb("test-app").BuildServiceProvider();
 
@@ -46,22 +50,22 @@ public class DependencyInjectionTests
     // The service provider is deliberately not disposed: shutting down the OTLP exporter waits on a
     // flush timeout against an endpoint that does not exist outside the cluster, which adds seconds
     // of dead wall clock to every test.
-    private static void RunWithEnvironment(string? hostname, Action action)
+    private static void RunWithEnvironment(string? kubernetesServiceHost, Action action)
     {
-        var originalRunningInContainer = Environment.GetEnvironmentVariable(RunningInContainerVariable);
-        var originalHostname = Environment.GetEnvironmentVariable(HostnameVariable);
+        var originalServiceHost = Environment.GetEnvironmentVariable(KubernetesServiceHostVariable);
+        var originalGitHubActions = Environment.GetEnvironmentVariable(GitHubActionsVariable);
 
         try
         {
-            Environment.SetEnvironmentVariable(RunningInContainerVariable, "true");
-            Environment.SetEnvironmentVariable(HostnameVariable, hostname);
+            Environment.SetEnvironmentVariable(KubernetesServiceHostVariable, kubernetesServiceHost);
+            Environment.SetEnvironmentVariable(GitHubActionsVariable, null);
 
             action();
         }
         finally
         {
-            Environment.SetEnvironmentVariable(RunningInContainerVariable, originalRunningInContainer);
-            Environment.SetEnvironmentVariable(HostnameVariable, originalHostname);
+            Environment.SetEnvironmentVariable(KubernetesServiceHostVariable, originalServiceHost);
+            Environment.SetEnvironmentVariable(GitHubActionsVariable, originalGitHubActions);
         }
     }
 }

--- a/src/Likvido.Web.Tests/EnvironmentCollection.cs
+++ b/src/Likvido.Web.Tests/EnvironmentCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Likvido.Web.Tests;
+
+/// <summary>
+/// Applied to every test class that reads or writes process-wide environment variables, so they
+/// cannot run concurrently with each other. xunit serialises tests within a single collection, but
+/// puts each class in its own collection by default — which would let two such classes race. Naming
+/// one collection and sharing it is what actually makes the serialisation hold.
+/// </summary>
+[CollectionDefinition(Name)]
+public class EnvironmentCollection
+{
+    public const string Name = "Environment variables";
+}

--- a/src/Likvido.Web/DependencyInjection.cs
+++ b/src/Likvido.Web/DependencyInjection.cs
@@ -1,14 +1,13 @@
-using Grafana.OpenTelemetry;
 using JetBrains.Annotations;
 using Likvido.Identity.PrincipalProviders;
 using Likvido.Metadata;
+using Likvido.Telemetry;
 using Likvido.Web.PrincipalProviders;
 using Likvido.Web.Services.IP;
 using Likvido.Web.Services.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Exporter;
 
 namespace Likvido.Web;
 
@@ -17,7 +16,6 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddLikvidoWeb(this IServiceCollection services, string webAppName)
     {
-        var runningInContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
         services.AddLogging(loggingBuilder =>
         {
             loggingBuilder.AddFilter("Azure", LogLevel.Warning);
@@ -25,37 +23,10 @@ public static class DependencyInjection
 
             loggingBuilder.AddConsole();
 
-            if (runningInContainer)
-            {
-                loggingBuilder.AddOpenTelemetry(options =>
-                {
-                    options.UseGrafana(settings =>
-                    {
-                        settings.ServiceName = webAppName;
-
-                        var podName = Environment.GetEnvironmentVariable("HOSTNAME");
-                        if (string.IsNullOrWhiteSpace(podName))
-                        {
-                            // Not running in Kubernetes - e.g. a Docker build stage, where BuildKit does not
-                            // set HOSTNAME. MachineName is always populated, and in a pod it is the pod name
-                            // anyway. OpenTelemetry throws on a null attribute value, so this must not be null.
-                            podName = Environment.MachineName;
-                        }
-
-                        if (!string.IsNullOrWhiteSpace(podName))
-                        {
-                            settings.ResourceAttributes.Add("k8s.pod.name", podName);
-                        }
-
-                        settings.ExporterSettings = new AgentOtlpExporter
-                        {
-                            Protocol = OtlpExportProtocol.Grpc,
-                            Endpoint = new Uri("http://grafana-alloy-otlp.grafana-alloy.svc.cluster.local:4317")
-                        };
-                    });
-                    options.IncludeScopes = true;
-                });
-            }
+            // Ships logs to the cluster's Grafana Alloy collector, and a no-op anywhere that is not a
+            // deployed workload — including a test host booting this application on an in-cluster CI
+            // runner. See Likvido.Telemetry for why that case needs saying out loud.
+            loggingBuilder.AddLikvidoOtlpLogging(webAppName);
         });
 
         services.AddHttpContextAccessor();

--- a/src/Likvido.Web/Likvido.Web.csproj
+++ b/src/Likvido.Web/Likvido.Web.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-        <PackageReference Include="Grafana.OpenTelemetry" Version="1.11.0" />
         <PackageReference Include="Likvido.Identity" Version="2.0.0" />
         <PackageReference Include="Likvido.Metadata" Version="1.0.1" />
+        <PackageReference Include="Likvido.Telemetry" Version="1.0.0" />
     </ItemGroup>
 </Project>

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.2.27</Version>
+        <Version>2.2.28</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes part of Likvido/Likvido.App#27896.

`AddLikvidoWeb` gated the OTLP exporter on `DOTNET_RUNNING_IN_CONTAINER`, which is `true` inside every GitHub Actions job — `ghcr.io/actions/actions-runner` is built on a Microsoft .NET base image. A test suite booting the application through `WebApplicationFactory` on an in-cluster runner therefore exported its logs to the staging Loki *as the live service*, and every negative-path test that logged at `Error` level paged OnCall.

The gate and the exporter wiring move to the new [Likvido.Telemetry](https://github.com/Likvido/Likvido.Telemetry) package, which also means `Likvido.Robot` stops carrying a second copy of them. The new gate says what it actually means: in a Kubernetes pod, and not a CI job.

Verified through the real `AddLikvidoWeb`, with `DOTNET_RUNNING_IN_CONTAINER=true` in all four cases:

| Scenario | `KUBERNETES_SERVICE_HOST` | `GITHUB_ACTIONS` | Exports to Loki |
| --- | --- | --- | --- |
| Real pod | set | — | **true** |
| CI in cluster | set | `true` | **false** |
| Dev machine | — | — | false |
| GitHub-hosted runner | — | `true` | false |

### On the tests

They move with the code they covered. The missing-`HOSTNAME` regression from #27873 is now a Likvido.Telemetry test; these two only prove `AddLikvidoWeb` composes with the shared call.

They also clear `GITHUB_ACTIONS` — without that, the in-a-pod case would quietly assert nothing on a GitHub-hosted runner while still passing locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved application telemetry and logging integration for more consistent monitoring across deployment environments.

* **Bug Fixes**
  * Improved detection of applications running inside and outside Kubernetes environments.

* **Tests**
  * Expanded validation of logging behavior across deployment scenarios and improved test isolation.

* **Chores**
  * Updated the project version to 2.2.28.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->