### PR TITLE
Restrict the publish workflow's token permissions

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -8,6 +8,11 @@ on:
       - src/version.props
       - .github/workflows/nuget.yml
 
+# The job only checks out the repository and pushes the package to nuget.org, which is authenticated
+# with NUGET_API_KEY rather than the job token, so read access to the contents is all it needs.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Clears CodeQL alert #3, `actions/missing-workflow-permissions` — the last open alert on this
repository. `nuget.yml` ran with the default `GITHUB_TOKEN` scope.

`contents: read` is sufficient and minimal: the job checks out the repository and pushes the package
to nuget.org, which authenticates with `NUGET_API_KEY` rather than the job token (verified in
`likvido/action-nuget` — it only runs `dotnet build` / `pack` / `nuget push`, no GitHub API calls),
and `actions/checkout` already runs with `persist-credentials: false`.

This is the same rule that was flagged on `testrunner.yml` in #52 and fixed there; `nuget.yml`
predates it, and CodeQL only comments on files a pull request touches, so it stayed quiet.

## One thing to expect on merge

`nuget.yml` triggers on pushes to `main` that touch `.github/workflows/nuget.yml` — its own path — so
merging this fires a publish run. That run is a no-op: `version.props` is unchanged at 2.2.28, which
is already on nuget.org, and `action-nuget` pushes with `--skip-duplicate`. No version bump is
included here, deliberately, since no library code changed.