### PR TITLE
Likvido/Likvido.App#27525 Publish via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -8,10 +8,11 @@ on:
       - src/version.props
       - .github/workflows/nuget.yml
 
-# The job only checks out the repository and pushes the package to nuget.org, which is authenticated
-# with NUGET_API_KEY rather than the job token, so read access to the contents is all it needs.
+# The job checks out the repository and publishes to nuget.org with Trusted Publishing, so it needs
+# read access to the contents and permission to request an OIDC token for the token exchange.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -29,7 +30,7 @@ jobs:
           dotnet-version: 10.x
 
       - name: Publish NuGet
-        uses: likvido/action-nuget@v1
+        uses: likvido/action-nuget@v2
         with:
           project: src/Likvido.Web/Likvido.Web.csproj
-          nuget-key: ${{ secrets.NUGET_API_KEY }}
+          nuget-user: ${{ vars.NUGET_USER }}


### PR DESCRIPTION
Part of Likvido/Likvido.App#27525 - migrating all 13 publishing repos off the shared `NUGET_API_KEY` org secret. Verified on the [`Likvido.Metadata` pilot](https://github.com/Likvido/Likvido.Metadata/pull/5).

### Changes
- `likvido/action-nuget@v1` → [`@v2`](https://github.com/Likvido/action-nuget/releases/tag/v2)
- `nuget-key: ${{ secrets.NUGET_API_KEY }}` → `nuget-user: ${{ vars.NUGET_USER }}`
- `id-token: write` added to `permissions` (needed for OIDC; cannot be set inside a composite action). `contents: read` is retained because specifying any permission zeroes the unlisted scopes.

### ⚠️ Register the Trusted Publishing policy before merging
This repo needs a policy on nuget.org first, created from the **`spewu-likvido`** account: Package Owner `Likvido`, CI/CD Provider `GitHub Actions`, Repository Owner `Likvido`, Repository `Likvido.Web`, Workflow File `nuget.yml`, Environment blank.

Note `NUGET_USER` is the policy **creator**, not the package owner - passing the owner fails with `No matching trust policy owned by user 'Likvido'`.

### Merging is a safe dry run
The trigger's path filter includes `.github/workflows/nuget.yml`, so merging runs the workflow immediately at the current already-published version. With `--skip-duplicate` the push is a no-op, which exercises the full OIDC exchange without releasing anything. A real publish only happens on the next `version.props` bump.